### PR TITLE
Add TypeScript support

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,6 +3,8 @@ const vueCompiler = require('vue-template-compiler');
 const vueNextCompiler = require('vue-template-es2015-compiler');
 const babelCore = require('babel-core');
 const findBabelConfig = require('find-babel-config');
+const tsc = require('typescript');
+const tsconfig = require('tsconfig');
 
 const transformBabel = src => {
   const {config} = findBabelConfig.sync(process.cwd());
@@ -19,6 +21,30 @@ const transformBabel = src => {
     console.error('Failed to compile scr with `babel` at `vue-preprocessor`');
   }
   return result;
+};
+
+
+const transformTs = (src, path) => {
+  const {config} = tsconfig.loadSync(process.cwd());
+  let result;
+  try {
+    result = tsc.transpile(
+      src,
+      config.compilerOptions,
+      path,
+      []
+    );
+  } catch (error) {
+    // eslint-disable-next-line
+    console.error('Failed to compile src with `tsc` at `vue-preprocessor`');
+  }
+  return result;
+};
+
+const transforms = {
+  'ts': transformTs,
+  'typescript': transformTs,
+  'babel': transformBabel
 };
 
 const extractHTML = (template, templatePath) => {
@@ -61,7 +87,7 @@ module.exports = {
     // @author https://github.com/locobert
     // heavily based on vueify (Copyright (c) 2014-2016 Evan You)
     const { script, template } = vueCompiler.parseComponent(src, { pad: true});
-    const transformedScript = transformBabel(script.content);
+    const transformedScript = transforms[script.lang || 'babel'](script.content);
     let render;
     let staticRenderFns;
     if (template) {

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "jest": "^19.0.2",
     "pug": "^2.0.0-beta6",
     "vue": "^2.1.4",
+    "vue-property-decorator": "^4.0.0",
     "vue-template-compiler": "^2.1.4",
     "vue-template-es2015-compiler": "^1.3.2"
   },
@@ -49,6 +50,8 @@
   },
   "dependencies": {
     "babel-plugin-transform-runtime": "^6.23.0",
-    "find-babel-config": "^1.0.1"
+    "find-babel-config": "^1.0.1",
+    "tsconfig": "^6.0.0",
+    "typescript": "^2.2.2"
   }
 }

--- a/test/fixtures/TsComponent.vue
+++ b/test/fixtures/TsComponent.vue
@@ -1,0 +1,26 @@
+<template>
+  <div id="app">
+    <div class="lorem-class">some test text</div>
+    <button v-on:click="clickHandler('value passed to clickHandler')">Click Me!</button>
+  </div>
+</template>
+
+<script lang="ts">
+  import Vue = require('vue')
+  import { Component } from 'vue-property-decorator'
+
+  @Component
+  export default class App extends Vue {
+    name = 'app'
+    clickHandler(input) {
+      return input + 1;
+    }
+  }
+</script>
+
+<style>
+  body {
+    color: red;
+  }
+</style>
+

--- a/test/fixtures/TypescriptComponent.vue
+++ b/test/fixtures/TypescriptComponent.vue
@@ -1,0 +1,26 @@
+<template>
+  <div id="app">
+    <div class="lorem-class">some test text</div>
+    <button v-on:click="clickHandler('value passed to clickHandler')">Click Me!</button>
+  </div>
+</template>
+
+<script lang="typescript">
+  import Vue = require('vue')
+  import { Component } from 'vue-property-decorator'
+
+  @Component
+  export default class App extends Vue {
+    name = 'app'
+    clickHandler(input) {
+      return input + 1;
+    }
+  }
+</script>
+
+<style>
+  body {
+    color: red;
+  }
+</style>
+

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -1,5 +1,20 @@
 import Vue from 'vue';
 import FooComponent from './fixtures/FooComponent.vue';
+import TsComponent from './fixtures/TsComponent.vue';
+import TypescriptComponent from './fixtures/TypescriptComponent.vue';
+
+const doTest = (vm) => {
+  const mockFn = jest.fn();
+  vm.$children[0].clickHandler = mockFn;
+
+  // check if template HTML compiled properly
+  expect(vm.$el).toBeDefined();
+  expect(vm.$el.querySelector('.lorem-class').textContent).toEqual('some test text');
+
+  // check if template calls vue methods
+  vm.$el.querySelector('button').click();
+  expect(mockFn.mock.calls[0][0]).toBe('value passed to clickHandler');
+};
 
 describe('preprocessor', () => {
   it('should process a `.vue` file', () => {
@@ -7,15 +22,25 @@ describe('preprocessor', () => {
       el: document.createElement('div'),
       render: h => h(FooComponent)
     });
-    const mockFn = jest.fn();
-    vm.$children[0].clickHandler = mockFn;
 
-    // check if template HTML compiled properly
-    expect(vm.$el).toBeDefined();
-    expect(vm.$el.querySelector('.lorem-class').textContent).toEqual('some test text');
+    doTest(vm);
+  });
 
-    // check if template calls vue methods
-    vm.$el.querySelector('button').click();
-    expect(mockFn.mock.calls[0][0]).toBe('value passed to clickHandler');
+  it('should process a `.vue` file with ts lang', () => {
+    const vm = new Vue({
+      el: document.createElement('div'),
+      render: h => h(TsComponent)
+    });
+
+    doTest(vm);
+  });
+
+  it('should process a `.vue` file with typescript lang', () => {
+    const vm = new Vue({
+      el: document.createElement('div'),
+      render: h => h(TypescriptComponent)
+    });
+
+    doTest(vm);
   });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -2432,6 +2432,10 @@ rechoir@^0.6.2:
   dependencies:
     resolve "^1.1.6"
 
+reflect-metadata@^0.1.9:
+  version "0.1.10"
+  resolved "https://registry.yarnpkg.com/reflect-metadata/-/reflect-metadata-0.1.10.tgz#b4f83704416acad89988c9b15635d47e03b9344a"
+
 regenerate@^1.2.1:
   version "1.3.2"
   resolved "https://registry.yarnpkg.com/regenerate/-/regenerate-1.3.2.tgz#d1941c67bad437e1be76433add5b385f95b19260"
@@ -2726,7 +2730,7 @@ strip-bom@^2.0.0:
   dependencies:
     is-utf8 "^0.2.0"
 
-strip-json-comments@~2.0.1:
+strip-json-comments@^2.0.0, strip-json-comments@~2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-2.0.1.tgz#3c531942e908c2697c0ec344858c286c7ca0a60a"
 
@@ -2807,6 +2811,13 @@ tryit@^1.0.1:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/tryit/-/tryit-1.0.3.tgz#393be730a9446fd1ead6da59a014308f36c289cb"
 
+tsconfig@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/tsconfig/-/tsconfig-6.0.0.tgz#6b0e8376003d7af1864f8df8f89dd0059ffcd032"
+  dependencies:
+    strip-bom "^3.0.0"
+    strip-json-comments "^2.0.0"
+
 tunnel-agent@^0.6.0:
   version "0.6.0"
   resolved "https://registry.yarnpkg.com/tunnel-agent/-/tunnel-agent-0.6.0.tgz#27a5dea06b36b04a0a9966774b290868f0fc40fd"
@@ -2826,6 +2837,10 @@ type-check@~0.3.2:
 typedarray@^0.0.6:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
+
+typescript@^2.2.2:
+  version "2.2.2"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.2.2.tgz#606022508479b55ffa368b58fee963a03dfd7b0c"
 
 uglify-js@^2.6, uglify-js@^2.6.1:
   version "2.8.15"
@@ -2871,9 +2886,20 @@ void-elements@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/void-elements/-/void-elements-2.0.1.tgz#c066afb582bb1cb4128d60ea92392e94d5e9dbec"
 
-vue-template-compiler@^2.1.4:
-  version "2.2.5"
-  resolved "https://registry.yarnpkg.com/vue-template-compiler/-/vue-template-compiler-2.2.5.tgz#71b1366c3f716e8137a87f82591de9f816609b57"
+vue-class-component@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/vue-class-component/-/vue-class-component-5.0.0.tgz#6cc52502fa40a05100ffc4cf2dfa3a3f849b8e0b"
+
+vue-property-decorator@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/vue-property-decorator/-/vue-property-decorator-4.0.0.tgz#42a0b00d30e53ffc57af0ae10498777981c6d2c4"
+  dependencies:
+    reflect-metadata "^0.1.9"
+    vue-class-component "^5.0.0"
+
+vue-template-compiler@2.1.4:
+  version "2.1.4"
+  resolved "https://registry.yarnpkg.com/vue-template-compiler/-/vue-template-compiler-2.1.4.tgz#ce99cb9c2f5842062d3b744c716224b613f198d4"
   dependencies:
     de-indent "^1.0.2"
     he "^1.1.0"


### PR DESCRIPTION
This patch adds support for compiling the body of the `<script>` tag which uses
either `lang="ts"` or `lang="typescript"` using TypeScript compiler instead of
Babel. Full backwards compatibility is maintained by making Babel a fallback
compiler if the lang attrib is not one of the 'ts', 'typescript', or 'babel'.

Locating and loading of the typescript configuration is deferred to tsconfig
package.

In order to unit-test the preprocessor, new fixture components are added which
use the class-based component format. [vue-property-decorator](https://github.com/kaorun343/vue-property-decorator) package is added as
a development dependency to support this component.