### PR TITLE
TypeScript support (fixed)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # jest-vue-preprocessor
 [![Build Status](https://travis-ci.org/vire/jest-vue-preprocessor.svg?branch=master)](https://travis-ci.org/vire/jest-vue-preprocessor) [![npm version](https://badge.fury.io/js/jest-vue-preprocessor.svg)](https://badge.fury.io/js/jest-vue-preprocessor) [![codecov](https://codecov.io/gh/vire/jest-vue-preprocessor/branch/master/graph/badge.svg)](https://codecov.io/gh/vire/jest-vue-preprocessor)
 
-A [locoslab/vue-typescript-jest](https://github.com/locoslab/vue-typescript-jest) JavaScript port to allow Jest load [.vue files](https://vue-loader.vuejs.org/en/) in tests.
+A [locoslab/vue-typescript-jest](https://github.com/locoslab/vue-typescript-jest) JavaScript port to allow Jest load [.vue files](https://vue-loader.vuejs.org/en/) in tests. This package supports both ES6 (Babel) and TypeScript.
 
 Portions both preprocessors are heavily based [vueify](https://github.com/vuejs/vueify) (Copyright (c) 2014-2016 Evan You).
 

--- a/index.js
+++ b/index.js
@@ -1,10 +1,10 @@
 /* eslint-env node */
+const path = require('path');
 const vueCompiler = require('vue-template-compiler');
 const vueNextCompiler = require('vue-template-es2015-compiler');
 const babelCore = require('babel-core');
 const findBabelConfig = require('find-babel-config');
 const tsc = require('typescript');
-const tsconfig = require('tsconfig');
 
 const transformBabel = src => {
   const {config} = findBabelConfig.sync(process.cwd());
@@ -23,17 +23,19 @@ const transformBabel = src => {
   return result;
 };
 
+const getTsConfig = () => {
+  try {
+    return require(path.resolve(process.cwd(), 'tsconfig.json'));
+  } catch (error) {
+    return {};
+  }
+};
 
 const transformTs = (src, path) => {
-  const {config} = tsconfig.loadSync(process.cwd());
+  const  {compilerOptions} = getTsConfig();
   let result;
   try {
-    result = tsc.transpile(
-      src,
-      config.compilerOptions,
-      path,
-      []
-    );
+    result = tsc.transpile(src, compilerOptions, path, []);
   } catch (error) {
     // eslint-disable-next-line
     console.error('Failed to compile src with `tsc` at `vue-preprocessor`');
@@ -42,9 +44,9 @@ const transformTs = (src, path) => {
 };
 
 const transforms = {
-  'ts': transformTs,
-  'typescript': transformTs,
-  'babel': transformBabel
+  ts: transformTs,
+  typescript: transformTs,
+  babel: transformBabel
 };
 
 const extractHTML = (template, templatePath) => {

--- a/package.json
+++ b/package.json
@@ -51,7 +51,6 @@
   "dependencies": {
     "babel-plugin-transform-runtime": "^6.23.0",
     "find-babel-config": "^1.0.1",
-    "tsconfig": "^6.0.0",
     "typescript": "^2.2.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -33,8 +33,9 @@
     "eslint": "^3.11.1",
     "jest": "^19.0.2",
     "pug": "^2.0.0-beta6",
-    "vue": "^2.1.4",
-    "vue-template-compiler": "^2.1.4",
+    "vue": "^2.2.6",
+    "vue-property-decorator": "^4.0.0",
+    "vue-template-compiler": "^2.2.6",
     "vue-template-es2015-compiler": "^1.3.2"
   },
   "jest": {
@@ -49,6 +50,8 @@
   },
   "dependencies": {
     "babel-plugin-transform-runtime": "^6.23.0",
-    "find-babel-config": "^1.0.1"
+    "find-babel-config": "^1.0.1",
+    "tsconfig": "^6.0.0",
+    "typescript": "^2.2.2"
   }
 }

--- a/test/fixtures/TsComponent.vue
+++ b/test/fixtures/TsComponent.vue
@@ -1,0 +1,26 @@
+<template>
+  <div id="app">
+    <div class="lorem-class">some test text</div>
+    <button v-on:click="clickHandler('value passed to clickHandler')">Click Me!</button>
+  </div>
+</template>
+
+<script lang="ts">
+  import Vue = require('vue')
+  import { Component } from 'vue-property-decorator'
+
+  @Component
+  export default class App extends Vue {
+    name = 'app'
+    clickHandler(input) {
+      return input + 1;
+    }
+  }
+</script>
+
+<style>
+  body {
+    color: red;
+  }
+</style>
+

--- a/test/fixtures/TypescriptComponent.vue
+++ b/test/fixtures/TypescriptComponent.vue
@@ -1,0 +1,26 @@
+<template>
+  <div id="app">
+    <div class="lorem-class">some test text</div>
+    <button v-on:click="clickHandler('value passed to clickHandler')">Click Me!</button>
+  </div>
+</template>
+
+<script lang="typescript">
+  import Vue = require('vue')
+  import { Component } from 'vue-property-decorator'
+
+  @Component
+  export default class App extends Vue {
+    name = 'app'
+    clickHandler(input) {
+      return input + 1;
+    }
+  }
+</script>
+
+<style>
+  body {
+    color: red;
+  }
+</style>
+

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -1,21 +1,36 @@
 import Vue from 'vue';
 import FooComponent from './fixtures/FooComponent.vue';
+import TsComponent from './fixtures/TsComponent.vue';
+import TypescriptComponent from './fixtures/TypescriptComponent.vue';
+
+const doTest = (Component) => {
+  const vm = new Vue({
+    el: document.createElement('div'),
+    render: h => h(Component)
+  });
+
+  const mockFn = jest.fn();
+  vm.$children[0].clickHandler = mockFn;
+
+  // check if template HTML compiled properly
+  expect(vm.$el).toBeDefined();
+  expect(vm.$el.querySelector('.lorem-class').textContent).toEqual('some test text');
+
+  // check if template calls vue methods
+  vm.$el.querySelector('button').click();
+  expect(mockFn.mock.calls[0][0]).toBe('value passed to clickHandler');
+};
 
 describe('preprocessor', () => {
   it('should process a `.vue` file', () => {
-    const vm = new Vue({
-      el: document.createElement('div'),
-      render: h => h(FooComponent)
-    });
-    const mockFn = jest.fn();
-    vm.$children[0].clickHandler = mockFn;
+    doTest(FooComponent);
+  });
 
-    // check if template HTML compiled properly
-    expect(vm.$el).toBeDefined();
-    expect(vm.$el.querySelector('.lorem-class').textContent).toEqual('some test text');
+  it('should process a `.vue` file with ts lang', () => {
+    doTest(TsComponent);
+  });
 
-    // check if template calls vue methods
-    vm.$el.querySelector('button').click();
-    expect(mockFn.mock.calls[0][0]).toBe('value passed to clickHandler');
+  it('should process a `.vue` file with typescript lang', () => {
+    doTest(TypescriptComponent);
   });
 });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "target": "es5",
+    "lib": [
+      "dom",
+      "es2015"
+    ],
+    "module": "commonjs",
+    "moduleResolution": "node",
+    "isolatedModules": false,
+    "experimentalDecorators": true,
+    "noImplicitAny": true,
+    "noImplicitThis": true,
+    "strictNullChecks": true,
+    "removeComments": true,
+    "suppressImplicitAnyIndexErrors": true,
+    "allowSyntheticDefaultImports": true
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2897,9 +2897,9 @@ vue-property-decorator@^4.0.0:
     reflect-metadata "^0.1.9"
     vue-class-component "^5.0.0"
 
-vue-template-compiler@2.1.4:
-  version "2.1.4"
-  resolved "https://registry.yarnpkg.com/vue-template-compiler/-/vue-template-compiler-2.1.4.tgz#ce99cb9c2f5842062d3b744c716224b613f198d4"
+vue-template-compiler@^2.2.6:
+  version "2.2.6"
+  resolved "https://registry.yarnpkg.com/vue-template-compiler/-/vue-template-compiler-2.2.6.tgz#2e2928daf0cd0feca9dfc35a9729adeae173ec68"
   dependencies:
     de-indent "^1.0.2"
     he "^1.1.0"
@@ -2908,9 +2908,9 @@ vue-template-es2015-compiler@^1.3.2:
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/vue-template-es2015-compiler/-/vue-template-es2015-compiler-1.5.1.tgz#0c36cc57aa3a9ec13e846342cb14a72fcac8bd93"
 
-vue@^2.1.4:
-  version "2.2.5"
-  resolved "https://registry.yarnpkg.com/vue/-/vue-2.2.5.tgz#528eba68447d7eff99f86767b31176aa656c6963"
+vue@^2.2.6:
+  version "2.2.6"
+  resolved "https://registry.yarnpkg.com/vue/-/vue-2.2.6.tgz#451714b394dd6d4eae7b773c40c2034a59621aed"
 
 walker@~1.0.5:
   version "1.0.7"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2432,6 +2432,10 @@ rechoir@^0.6.2:
   dependencies:
     resolve "^1.1.6"
 
+reflect-metadata@^0.1.9:
+  version "0.1.10"
+  resolved "https://registry.yarnpkg.com/reflect-metadata/-/reflect-metadata-0.1.10.tgz#b4f83704416acad89988c9b15635d47e03b9344a"
+
 regenerate@^1.2.1:
   version "1.3.2"
   resolved "https://registry.yarnpkg.com/regenerate/-/regenerate-1.3.2.tgz#d1941c67bad437e1be76433add5b385f95b19260"
@@ -2726,7 +2730,7 @@ strip-bom@^2.0.0:
   dependencies:
     is-utf8 "^0.2.0"
 
-strip-json-comments@~2.0.1:
+strip-json-comments@^2.0.0, strip-json-comments@~2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-2.0.1.tgz#3c531942e908c2697c0ec344858c286c7ca0a60a"
 
@@ -2807,6 +2811,13 @@ tryit@^1.0.1:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/tryit/-/tryit-1.0.3.tgz#393be730a9446fd1ead6da59a014308f36c289cb"
 
+tsconfig@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/tsconfig/-/tsconfig-6.0.0.tgz#6b0e8376003d7af1864f8df8f89dd0059ffcd032"
+  dependencies:
+    strip-bom "^3.0.0"
+    strip-json-comments "^2.0.0"
+
 tunnel-agent@^0.6.0:
   version "0.6.0"
   resolved "https://registry.yarnpkg.com/tunnel-agent/-/tunnel-agent-0.6.0.tgz#27a5dea06b36b04a0a9966774b290868f0fc40fd"
@@ -2826,6 +2837,10 @@ type-check@~0.3.2:
 typedarray@^0.0.6:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
+
+typescript@^2.2.2:
+  version "2.2.2"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.2.2.tgz#606022508479b55ffa368b58fee963a03dfd7b0c"
 
 uglify-js@^2.6, uglify-js@^2.6.1:
   version "2.8.15"
@@ -2871,9 +2886,20 @@ void-elements@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/void-elements/-/void-elements-2.0.1.tgz#c066afb582bb1cb4128d60ea92392e94d5e9dbec"
 
-vue-template-compiler@^2.1.4:
-  version "2.2.5"
-  resolved "https://registry.yarnpkg.com/vue-template-compiler/-/vue-template-compiler-2.2.5.tgz#71b1366c3f716e8137a87f82591de9f816609b57"
+vue-class-component@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/vue-class-component/-/vue-class-component-5.0.0.tgz#6cc52502fa40a05100ffc4cf2dfa3a3f849b8e0b"
+
+vue-property-decorator@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/vue-property-decorator/-/vue-property-decorator-4.0.0.tgz#42a0b00d30e53ffc57af0ae10498777981c6d2c4"
+  dependencies:
+    reflect-metadata "^0.1.9"
+    vue-class-component "^5.0.0"
+
+vue-template-compiler@2.1.4:
+  version "2.1.4"
+  resolved "https://registry.yarnpkg.com/vue-template-compiler/-/vue-template-compiler-2.1.4.tgz#ce99cb9c2f5842062d3b744c716224b613f198d4"
   dependencies:
     de-indent "^1.0.2"
     he "^1.1.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2730,7 +2730,7 @@ strip-bom@^2.0.0:
   dependencies:
     is-utf8 "^0.2.0"
 
-strip-json-comments@^2.0.0, strip-json-comments@~2.0.1:
+strip-json-comments@~2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-2.0.1.tgz#3c531942e908c2697c0ec344858c286c7ca0a60a"
 
@@ -2810,13 +2810,6 @@ trim-right@^1.0.1:
 tryit@^1.0.1:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/tryit/-/tryit-1.0.3.tgz#393be730a9446fd1ead6da59a014308f36c289cb"
-
-tsconfig@^6.0.0:
-  version "6.0.0"
-  resolved "https://registry.yarnpkg.com/tsconfig/-/tsconfig-6.0.0.tgz#6b0e8376003d7af1864f8df8f89dd0059ffcd032"
-  dependencies:
-    strip-bom "^3.0.0"
-    strip-json-comments "^2.0.0"
 
 tunnel-agent@^0.6.0:
   version "0.6.0"


### PR DESCRIPTION
This patch adds support for compiling the body of the `<script>` tag which uses
either `lang="ts"` or `lang="typescript"` using TypeScript compiler instead of
Babel. Full backwards compatibility is maintained by making Babel a fallback
compiler if the lang attrib is not one of the 'ts', 'typescript', or 'babel'.

Locating and loading of the typescript configuration is deferred to tsconfig
package.

In order to unit-test the preprocessor, new fixture components are added which
use the class-based component format. vue-property-decorator package is added as
a development dependency to support this component.