### PR TITLE
chore: update vue-template-compiler

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "find-babel-config": "1.1.0",
     "typescript": "2.4.2",
     "vue-property-decorator": "5.1.1",
-    "vue-template-compiler": "2.4.1",
+    "vue-template-compiler": "2.4.2",
     "vue-template-es2015-compiler": "1.5.3"
   },
   "devDependencies": {
@@ -41,7 +41,7 @@
     "pug": "2.0.0-rc.2",
     "semantic-release": "6.3.6",
     "validate-commit-msg": "2.13.0",
-    "vue": "2.4.1"
+    "vue": "2.4.2"
   },
   "scripts": {
     "cz": "git-cz",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4022,9 +4022,9 @@ vue-property-decorator@5.1.1:
     reflect-metadata "^0.1.9"
     vue-class-component "^5.0.0"
 
-vue-template-compiler@2.4.1:
-  version "2.4.1"
-  resolved "https://registry.yarnpkg.com/vue-template-compiler/-/vue-template-compiler-2.4.1.tgz#20115cf8714f222f9be4111ec75b079a1c9b8197"
+vue-template-compiler@2.4.2:
+  version "2.4.2"
+  resolved "https://registry.yarnpkg.com/vue-template-compiler/-/vue-template-compiler-2.4.2.tgz#5a45d843f148b098f6c1d1e35ac20c4956d30ad1"
   dependencies:
     de-indent "^1.0.2"
     he "^1.1.0"
@@ -4033,9 +4033,9 @@ vue-template-es2015-compiler@1.5.3:
   version "1.5.3"
   resolved "https://registry.yarnpkg.com/vue-template-es2015-compiler/-/vue-template-es2015-compiler-1.5.3.tgz#22787de4e37ebd9339b74223bc467d1adee30545"
 
-vue@2.4.1:
-  version "2.4.1"
-  resolved "https://registry.yarnpkg.com/vue/-/vue-2.4.1.tgz#76e0b8eee614613532216b7bfe784e0b5695b160"
+vue@2.4.2:
+  version "2.4.2"
+  resolved "https://registry.yarnpkg.com/vue/-/vue-2.4.2.tgz#a9855261f191c978cc0dc1150531b8d08149b58c"
 
 walk@^2.3.9:
   version "2.3.9"


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: [CONTRIBUTING.md](https://github.com/vire/jest-vue-preprocessor/blob/master/docs/CONTRIBUTING.md)
- [x] There are no linting errors and code is properly formatted (your run before push `yarn lint`)
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[x] Other... Please describe:
```
Update vue-template-compiler, and vue for tests to pass

**What is the current behavior?** (You can also link to an open issue here)

Uses vue-template-compiler 2.4.1

**What is the new behavior?**

Uses vue-template-compiler 2.4.2

**Does this PR introduce a breaking change?** (check one with "x")
```
[x] Yes
[ ] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

Anyone using to compile vue 2.4.1 will get an error
