### PR TITLE
Support sourcemaps

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Portions both preprocessors are heavily based [vueify](https://github.com/vuejs/
           "js",
           "vue"
         ],
+        "mapCoverage": true,
         "transform": {
           "^.+\\.js$": "<rootDir>/node_modules/babel-jest",
           ".*\\.(vue)$": "<rootDir>/node_modules/jest-vue-preprocessor"

--- a/index.js
+++ b/index.js
@@ -1,53 +1,7 @@
 /* eslint-env node */
-const path = require('path');
 const vueCompiler = require('vue-template-compiler');
 const vueNextCompiler = require('vue-template-es2015-compiler');
-const babelCore = require('babel-core');
-const findBabelConfig = require('find-babel-config');
-const tsc = require('typescript');
-
-const transformBabel = src => {
-  const { config } = findBabelConfig.sync(process.cwd());
-  const transformOptions = {
-    presets: ['es2015'],
-    plugins: ['transform-runtime'],
-  };
-
-  let result;
-  try {
-    result = babelCore.transform(src, config || transformOptions).code;
-  } catch (error) {
-    // eslint-disable-next-line
-    console.error('Failed to compile scr with `babel` at `vue-preprocessor`');
-  }
-  return result;
-};
-
-const getTsConfig = () => {
-  try {
-    return require(path.resolve(process.cwd(), 'tsconfig.json'));
-  } catch (error) {
-    return {};
-  }
-};
-
-const transformTs = (src, path) => {
-  const { compilerOptions } = getTsConfig();
-  let result;
-  try {
-    result = tsc.transpile(src, compilerOptions, path, []);
-  } catch (error) {
-    // eslint-disable-next-line
-    console.error('Failed to compile src with `tsc` at `vue-preprocessor`');
-  }
-  return result;
-};
-
-const transforms = {
-  ts: transformTs,
-  typescript: transformTs,
-  babel: transformBabel,
-};
+const transforms = require('./transforms');
 
 const extractHTML = (template, templatePath) => {
   let resultHTML = '';
@@ -63,28 +17,6 @@ const extractHTML = (template, templatePath) => {
   return resultHTML;
 };
 
-const generateOutput = (script, renderFn, staticRenderFns) => {
-  let output = '';
-  output +=
-    '/* istanbul ignore next */;(function(){\n' +
-    script +
-    '\n})()\n' +
-    '/* istanbul ignore next */if (module.exports.__esModule) module.exports = module.exports.default\n';
-  output +=
-    '/* istanbul ignore next */var __vue__options__ = (typeof module.exports === "function"' +
-    '? module.exports.options: module.exports)\n';
-  if (renderFn && staticRenderFns) {
-    output +=
-      '/* istanbul ignore next */__vue__options__.render = ' +
-      renderFn +
-      '\n' +
-      '/* istanbul ignore next */__vue__options__.staticRenderFns = ' +
-      staticRenderFns +
-      '\n';
-  }
-  return output;
-};
-
 const stringifyRender = render => vueNextCompiler('function render () {' + render + '}');
 
 const stringifyStaticRender = staticRenderFns => `[${staticRenderFns.map(stringifyRender).join(',')}]`;
@@ -95,8 +27,13 @@ module.exports = {
     // LICENSE MIT
     // @author https://github.com/locobert
     // heavily based on vueify (Copyright (c) 2014-2016 Evan You)
-    const { script, template } = vueCompiler.parseComponent(src, { pad: true });
-    const transformedScript = script ? transforms[script.lang || 'babel'](script.content) : '';
+
+    const { script, template } = vueCompiler.parseComponent(src, { pad: false });
+
+    if (!script) {
+      return { code: '' };
+    }
+
     let render;
     let staticRenderFns;
     if (template) {
@@ -105,7 +42,8 @@ module.exports = {
       render = stringifyRender(res.render);
       staticRenderFns = stringifyStaticRender(res.staticRenderFns);
     }
+    const transformKey = script.lang || 'babel';
 
-    return generateOutput(transformedScript, render, staticRenderFns);
+    return transforms[transformKey](script.content, filePath, render, staticRenderFns);
   },
 };

--- a/package.json
+++ b/package.json
@@ -65,6 +65,15 @@
       "js",
       "vue"
     ],
+    "coverageThreshold": {
+      "global": {
+        "branches": 100,
+        "functions": 100,
+        "lines": 100,
+        "statements": 100
+      }
+    },
+    "mapCoverage": true,
     "moduleNameMapper": {
       "^test/fixtures/(.*)": "<rootDir>/test/fixtures/$1"
     },

--- a/test/fixtures/FooComponent.vue
+++ b/test/fixtures/FooComponent.vue
@@ -7,11 +7,17 @@
 
 <script>
   export default {
+    props: {
+      onClick: {
+        type: Function,
+        required: true
+      }
+    },
     name: 'app',
     methods: {
       clickHandler(input) {
-        return input + 1;
-      }
+        this.onClick(input);
+      },
     }
   }
 </script>

--- a/test/fixtures/TsComponent.vue
+++ b/test/fixtures/TsComponent.vue
@@ -7,13 +7,14 @@
 
 <script lang="ts">
   import Vue = require('vue')
-  import { Component } from 'vue-property-decorator'
+  import { Component, Prop } from 'vue-property-decorator'
 
   @Component
   export default class App extends Vue {
     name = 'app'
+    @Prop() onClick: Function
     clickHandler(input) {
-      return input + 1;
+      this.onClick(input);
     }
   }
 </script>

--- a/test/fixtures/TypescriptComponent.vue
+++ b/test/fixtures/TypescriptComponent.vue
@@ -7,13 +7,14 @@
 
 <script lang="typescript">
   import Vue = require('vue')
-  import { Component } from 'vue-property-decorator'
+  import { Component, Prop } from 'vue-property-decorator'
 
   @Component
   export default class App extends Vue {
     name = 'app'
+    @Prop() onClick: Function
     clickHandler(input) {
-      return input + 1;
+      this.onClick(input);
     }
   }
 </script>

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -5,13 +5,16 @@ import TypescriptComponent from './fixtures/TypescriptComponent.vue';
 import AbsolutePathComponent from 'test/fixtures/FooComponent.vue';
 
 const doTest = (Component) => {
+  const mockFn = jest.fn();
+
   const vm = new Vue({
     el: document.createElement('div'),
-    render: h => h(Component)
+    render: h => h(Component, {
+      props: {
+        onClick: mockFn
+      }
+    })
   });
-
-  const mockFn = jest.fn();
-  vm.$children[0].clickHandler = mockFn;
 
   // check if template HTML compiled properly
   expect(vm.$el).toBeDefined();

--- a/transforms/index.js
+++ b/transforms/index.js
@@ -1,0 +1,7 @@
+const transformTs = require('./transformTs');
+
+module.exports = {
+  ts: transformTs,
+  typescript: transformTs,
+  babel: require('./transformBabel'),
+};

--- a/transforms/transformBabel.js
+++ b/transforms/transformBabel.js
@@ -1,0 +1,69 @@
+/* eslint-env node */
+
+const template = require('babel-template');
+const babelCore = require('babel-core');
+const t = babelCore.types;
+const findBabelConfig = require('find-babel-config');
+
+const defaultConfig = {
+  presets: ['es2015'],
+  plugins: ['transform-runtime'],
+};
+
+function appendRenderPlugin(render, staticRenderFns) {
+  const buildVueOptions = template(`
+    var __vue__options__ = (
+      typeof module.exports === "function"
+      ? module.exports.options : module.exports
+    );
+    __vue__options__.render = ${render};
+    __vue__options__.staticRenderFns = ${staticRenderFns};
+  `);
+
+  return () => {
+    if (!render || !staticRenderFns) {
+      return {};
+    }
+
+    return {
+      visitor: {
+        Program: {
+          exit(path) {
+            path.pushContainer('body', buildVueOptions());
+          }
+        },
+        MemberExpression(path) {
+          if (path.get('object.name').node === 'exports' &&
+            path.get('property.name').node === 'default'
+          ) {
+            path.replaceWith(
+              t.memberExpression(t.identifier('module'), t.identifier('exports'))
+            );
+          }
+        }
+      }
+    };
+  };
+}
+
+module.exports = function transformBabel (src, filename, render, staticRenderFns, inputSourceMap) {
+  const { config = defaultConfig } = findBabelConfig.sync(process.cwd());
+
+  const combinedTransformOptions = Object.assign({}, config, {
+    sourceMaps: true,
+    inputSourceMap,
+    filename,
+    plugins: (config.plugins || []).concat([
+      appendRenderPlugin(render, staticRenderFns)
+    ])
+  });
+
+  let result;
+  try {
+    result = babelCore.transform(src, combinedTransformOptions);
+  } catch (error) {
+    // eslint-disable-next-line
+    console.error('Failed to compile scr with `babel` at `vue-preprocessor`');
+  }
+  return result;
+};

--- a/transforms/transformTs.js
+++ b/transforms/transformTs.js
@@ -1,0 +1,35 @@
+/* eslint-env node */
+
+const path = require('path');
+const tsc = require('typescript');
+const transformBabel = require('./transformBabel');
+
+const getTsConfig = () => {
+  try {
+    return require(path.resolve(process.cwd(), 'tsconfig.json'));
+  } catch (error) {
+    return {};
+  }
+};
+
+module.exports = function transformTs(src, filename, render, staticRenderFns) {
+  const compilerOptions = Object.assign(
+    {},
+    getTsConfig().compilerOptions,
+    {
+      sourceMap: true
+    }
+  );
+
+  try {
+    const {
+      outputText,
+      sourceMapText
+    } = tsc.transpileModule(src, { compilerOptions });
+
+    return transformBabel(outputText, filename, render, staticRenderFns, JSON.parse(sourceMapText));
+  } catch (error) {
+    // eslint-disable-next-line
+    console.error('Failed to compile src with `tsc` at `vue-preprocessor`');
+  }
+};


### PR DESCRIPTION
in order to have readable coverage reports

fix https://github.com/vire/jest-vue-preprocessor/issues/15

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: [CONTRIBUTING.md](https://github.com/vire/jest-vue-preprocessor/blob/master/docs/CONTRIBUTING.md)
- [x] There are no linting errors and code is properly formatted (your run before push `yarn lint`)
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** (check one with "x")
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)

coverage reports of vue files are faulty ref https://github.com/vire/jest-vue-preprocessor/issues/15

**What is the new behavior?**

coverage reports are still not perfect due to missing source map support of vue template processors and my lack of knowledge about typescript. But normal JS files transformed with babel should now be mapped 99% correctly

**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
