### PR TITLE
Support vue src imports

### DIFF
--- a/test/fixtures/srcImportComponent/srcImport.html
+++ b/test/fixtures/srcImportComponent/srcImport.html
@@ -1,0 +1,4 @@
+<div id="app">
+  <div class="lorem-class">some test text</div>
+  <button v-on:click="clickHandler('value passed to clickHandler')">Click Me!</button>
+</div>

--- a/test/fixtures/srcImportComponent/srcImport.js
+++ b/test/fixtures/srcImportComponent/srcImport.js
@@ -1,0 +1,14 @@
+export default {
+  props: {
+    onClick: {
+      type: Function,
+      required: true
+    }
+  },
+  name: 'app',
+  methods: {
+    clickHandler(input) {
+      this.onClick(input);
+    },
+  }
+};

--- a/test/fixtures/srcImportComponent/srcImportComponent.vue
+++ b/test/fixtures/srcImportComponent/srcImportComponent.vue
@@ -1,0 +1,8 @@
+<template src="./srcImport.html"></template>
+<script src="./srcImport.js"></script>
+
+<style>
+  body {
+    color: red;
+  }
+</style>

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -3,6 +3,7 @@ import FooComponent from './fixtures/FooComponent.vue';
 import TsComponent from './fixtures/TsComponent.vue';
 import TypescriptComponent from './fixtures/TypescriptComponent.vue';
 import AbsolutePathComponent from 'test/fixtures/FooComponent.vue';
+import srcImportComponent from './fixtures/srcImportComponent/srcImportComponent.vue';
 
 const doTest = (Component) => {
   const mockFn = jest.fn();
@@ -40,5 +41,9 @@ describe('preprocessor', () => {
 
   it('should process an absolute path of a `.vue` Component', () => {
     doTest(AbsolutePathComponent);
+  });
+
+  it('should process and parse a .vue component containing src referenecs', () => {
+    doTest(srcImportComponent);
   });
 });


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: [CONTRIBUTING.md](https://github.com/vire/jest-vue-preprocessor/blob/master/docs/CONTRIBUTING.md)
- [x] There are no linting errors and code is properly formatted (your run before push `yarn lint`)
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)
https://github.com/vire/jest-vue-preprocessor/issues/23


**What is the new behavior?**
Files referenced in the src attribute of either <template> or <script> tags are being parsed and dealt with as if they were placed inside these tags. Therefore, it should break additional template/script parsing


**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[X] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
Since the current implementation literally passes on the filename in the src attribute to a node file reader, it will only work with relative paths (I personally think this is the correct way to use src-imports in general). Any webpack aliases/modulenamemapper definitions will therefore not apply. This could be a follow-up task?