### PR TITLE
peerDependancies not updated to match dev

### DIFF
--- a/package.json
+++ b/package.json
@@ -99,7 +99,7 @@
     ]
   },
   "peerDependencies": {
-    "vue-template-compiler": "2.4.x",
-    "vue-template-es2015-compiler": "1.5.x"
+    "vue-template-compiler": "2.5.x",
+    "vue-template-es2015-compiler": "1.6.x"
   }
 }


### PR DESCRIPTION
During a recent update to devDependancies, peerDependancies were not updated to reflect the new verison requirements, causing an npm error. PR causing this bug can be found here: https://github.com/vire/jest-vue-preprocessor/pull/38

**Please check if the PR fulfills these requirements**
- [X] The commit message follows our guidelines: [CONTRIBUTING.md](https://github.com/vire/jest-vue-preprocessor/blob/master/docs/CONTRIBUTING.md)
- [X] There are no linting errors and code is properly formatted (your run before push `yarn lint`)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[X] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)
Warning on `npm install`
`npm WARN jest-vue-preprocessor@1.3.0 requires a peer of vue-template-compiler@2.4.x but none was installed.
npm WARN jest-vue-preprocessor@1.3.0 requires a peer of vue-template-es2015-compiler@1.5.x but none was installed.`


**What is the new behavior?**
No warning


**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[X] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
