### PR TITLE
Show message from Babel

### DIFF
--- a/transforms/transformBabel.js
+++ b/transforms/transformBabel.js
@@ -60,7 +60,7 @@ module.exports = function transformBabel(src, filename, render, staticRenderFns,
     result = babelCore.transform(src, combinedTransformOptions);
   } catch (error) {
     /* eslint-disable no-console */
-    console.error('Failed to compile scr with `babel` at `vue-preprocessor`');
+    console.error('Failed to compile src with `babel` at `vue-preprocessor`');
     console.error('Babel:', error);
     /* eslint-enable */
   }

--- a/transforms/transformBabel.js
+++ b/transforms/transformBabel.js
@@ -59,8 +59,10 @@ module.exports = function transformBabel(src, filename, render, staticRenderFns,
   try {
     result = babelCore.transform(src, combinedTransformOptions);
   } catch (error) {
-    // eslint-disable-next-line
+    /* eslint-disable no-console */
     console.error('Failed to compile scr with `babel` at `vue-preprocessor`');
+    console.error('Babel:', error);
+    /* eslint-enable */
   }
   return result;
 };


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: [CONTRIBUTING.md](https://github.com/vire/jest-vue-preprocessor/blob/master/docs/CONTRIBUTING.md)
- [x] There are no linting errors and code is properly formatted (your run before push `yarn lint`)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)

Suppressing an exception message from `babelCore.transform`.
I should have added print-debug manually for finding the actual problem when I see the current message "Failed to compile scr with `babel` at `vue-preprocessor`".

In my case, my `.babelrc` was wrong 😢  btw.

**What is the new behavior?**

- Dump the message from an exception such like print-debug I did
- Also had a fixing typo: `scr` -> `src`

**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
