### PR TITLE
Support for Functional Components

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 *.log
 node_modules
 coverage
+.idea

--- a/index.js
+++ b/index.js
@@ -45,8 +45,12 @@ const isAFunctionalComponent = template => {
   if (typeof template !== 'string' && Array.isArray(template))
     template = template.join(' ');
 
-  if (typeof template !== 'string')
+  if (typeof template !== 'string') {
+    console.log(template)
+    console.log(object.keys(template)
+    console.log(JSON.stringify(template))
     throw new Error(`template is not a string! ${template}`);
+  }
 
   return /template[^>]*functional/.test(template);
 };

--- a/index.js
+++ b/index.js
@@ -28,7 +28,7 @@ const extractHTML = (template, templatePath) => {
 
 const extractScriptContent = (script, scriptPath) => {
   if (!script) {
-    throw 'No script available to transform!';
+    throw 'No script available to transform';
   }
   if (script.content === '' && script.src !== '') {
     script.content = fs.readFileSync(path.resolve(path.dirname(scriptPath), script.src), 'utf8');
@@ -42,7 +42,7 @@ const stringifyStaticRender = staticRenderFns =>
   `[${staticRenderFns.map(stringifyRender).join(',')}]`;
 
 const isAFunctionalComponent = template =>
-  template && template.attrs && template.functional;
+  template && template.attrs && template.attrs.functional;
 
 module.exports = {
   process(src, filePath) {
@@ -58,12 +58,8 @@ module.exports = {
     // thus breaking any tests that use a functional component, just
     // return a dummy script.
     // @author https://github.com/candyapplecorn
-    if (!script && isAFunctionalComponent(template)) {
-      return ';'  
-    } else if (!script) {
-      console.log(JSON.stringify(template));
+    if (!script && isAFunctionalComponent(template))
       return ';'
-    }
 
     let render;
     let staticRenderFns;

--- a/index.js
+++ b/index.js
@@ -41,8 +41,7 @@ const stringifyRender = render => vueNextCompiler('function render () {' + rende
 const stringifyStaticRender = staticRenderFns =>
   `[${staticRenderFns.map(stringifyRender).join(',')}]`;
 
-const isAFunctionalComponent = template =>
-  template && template.attrs && template.attrs.functional;
+const isAFunctionalComponent = template => template && template.attrs && template.attrs.functional;
 
 module.exports = {
   process(src, filePath) {
@@ -52,14 +51,13 @@ module.exports = {
     // heavily based on vueify (Copyright (c) 2014-2016 Evan You)
 
     const { script, template } = vueCompiler.parseComponent(src, { pad: false });
-    
+
     // Vue has functional components now, which don't have script tags.
     // In order to not fail at trying to parse a non existent script and
     // thus breaking any tests that use a functional component, just
     // return a dummy script.
     // @author https://github.com/candyapplecorn
-    if (!script && isAFunctionalComponent(template))
-      return ';'
+    if (!script && isAFunctionalComponent(template)) return ';';
 
     let render;
     let staticRenderFns;

--- a/index.js
+++ b/index.js
@@ -52,13 +52,6 @@ module.exports = {
 
     const { script, template } = vueCompiler.parseComponent(src, { pad: false });
 
-    // Vue has functional components now, which don't have script tags.
-    // In order to not fail at trying to parse a non existent script and
-    // thus breaking any tests that use a functional component, just
-    // return a dummy script.
-    // @author https://github.com/candyapplecorn
-    if (!script && isAFunctionalComponent(template)) return ';';
-
     let render;
     let staticRenderFns;
     if (template) {
@@ -69,9 +62,11 @@ module.exports = {
     }
 
     let scriptContent = { code: '' };
-    scriptContent = extractScriptContent(script, filePath);
 
-    const transformKey = script.lang || 'babel';
+    if (!script && isAFunctionalComponent(template)) scriptContent = '';
+    else scriptContent = extractScriptContent(script, filePath);
+
+    const transformKey = (script && script.lang) || 'babel';
     return transforms[transformKey](scriptContent, filePath, render, staticRenderFns);
   },
 };

--- a/index.js
+++ b/index.js
@@ -47,7 +47,7 @@ const isAFunctionalComponent = template => {
 
   if (typeof template !== 'string') {
     console.log(template)
-    console.log(object.keys(template))
+    console.log(Object.keys(template))
     console.log(JSON.stringify(template))
     throw new Error(`template is not a string! ${template}`);
   }

--- a/index.js
+++ b/index.js
@@ -28,7 +28,7 @@ const extractHTML = (template, templatePath) => {
 
 const extractScriptContent = (script, scriptPath) => {
   if (!script) {
-    throw 'No script available to transform';
+    throw 'No script available to transform!';
   }
   if (script.content === '' && script.src !== '') {
     script.content = fs.readFileSync(path.resolve(path.dirname(scriptPath), script.src), 'utf8');

--- a/index.js
+++ b/index.js
@@ -41,6 +41,16 @@ const stringifyRender = render => vueNextCompiler('function render () {' + rende
 const stringifyStaticRender = staticRenderFns =>
   `[${staticRenderFns.map(stringifyRender).join(',')}]`;
 
+const isAFunctionalComponent = template => {
+  if (typeof template !== 'string' && Array.isArray(template))
+    template = template.join(' ');
+
+  if (typeof template !== 'string')
+    throw new Error(`template is not a string! ${template}`);
+
+  return /template[^>]*functional/.test(template);
+};
+
 module.exports = {
   process(src, filePath) {
     // code copied from https://github.com/locoslab/vue-typescript-jest/blob/master/preprocessor.js
@@ -55,7 +65,6 @@ module.exports = {
     // thus breaking any tests that use a functional component, just
     // return a dummy script.
     // @author https://github.com/candyapplecorn
-    const isAFunctionalComponent = template => /template[^>]*functional/.test(template);
     if (!script && isAFunctionalComponent(template)) {
       return ';'  
     }

--- a/index.js
+++ b/index.js
@@ -41,9 +41,8 @@ const stringifyRender = render => vueNextCompiler('function render () {' + rende
 const stringifyStaticRender = staticRenderFns =>
   `[${staticRenderFns.map(stringifyRender).join(',')}]`;
 
-const isAFunctionalComponent = template => {
-  return template && template.attrs && template.functional;
-};
+const isAFunctionalComponent = template => 
+  template && template.attrs && template.functional;
 
 module.exports = {
   process(src, filePath) {

--- a/index.js
+++ b/index.js
@@ -41,7 +41,7 @@ const stringifyRender = render => vueNextCompiler('function render () {' + rende
 const stringifyStaticRender = staticRenderFns =>
   `[${staticRenderFns.map(stringifyRender).join(',')}]`;
 
-const isAFunctionalComponent = template => 
+const isAFunctionalComponent = template =>
   template && template.attrs && template.functional;
 
 module.exports = {
@@ -60,6 +60,9 @@ module.exports = {
     // @author https://github.com/candyapplecorn
     if (!script && isAFunctionalComponent(template)) {
       return ';'  
+    } else if (!script) {
+      console.log(JSON.stringify(template));
+      return ';'
     }
 
     let render;

--- a/index.js
+++ b/index.js
@@ -49,6 +49,16 @@ module.exports = {
     // heavily based on vueify (Copyright (c) 2014-2016 Evan You)
 
     const { script, template } = vueCompiler.parseComponent(src, { pad: false });
+    
+    // Vue has functional components now, which don't have script tags.
+    // In order to not fail at trying to parse a non existent script and
+    // thus breaking any tests that use a functional component, just
+    // return a dummy script.
+    // @author https://github.com/candyapplecorn
+    const isAFunctionalComponent = template => /template[^>]*functional/.test(template);
+    if (!script && isAFunctionalComponent(template)) {
+      return ';'  
+    }
 
     let render;
     let staticRenderFns;

--- a/index.js
+++ b/index.js
@@ -47,7 +47,7 @@ const isAFunctionalComponent = template => {
 
   if (typeof template !== 'string') {
     console.log(template)
-    console.log(object.keys(template)
+    console.log(object.keys(template))
     console.log(JSON.stringify(template))
     throw new Error(`template is not a string! ${template}`);
   }

--- a/index.js
+++ b/index.js
@@ -42,17 +42,7 @@ const stringifyStaticRender = staticRenderFns =>
   `[${staticRenderFns.map(stringifyRender).join(',')}]`;
 
 const isAFunctionalComponent = template => {
-  if (typeof template !== 'string' && Array.isArray(template))
-    template = template.join(' ');
-
-  if (typeof template !== 'string') {
-    console.log(template)
-    console.log(Object.keys(template))
-    console.log(JSON.stringify(template))
-    throw new Error(`template is not a string! ${template}`);
-  }
-
-  return /template[^>]*functional/.test(template);
+  return template && template.attrs && template.functional;
 };
 
 module.exports = {

--- a/test/fixtures/FunctionalComponent.vue
+++ b/test/fixtures/FunctionalComponent.vue
@@ -1,6 +1,6 @@
 <template functional>
   <div id="app" class="functional-component">
     <div class="lorem-class">some test text</div>
-    <button v-on:click="() => props.onClick('value passed to clickHandler')">Click Me!</button>
+    <button v-on:click="props.onClick('value passed to clickHandler')">Click Me!</button>
   </div>
 </template>

--- a/test/fixtures/FunctionalComponent.vue
+++ b/test/fixtures/FunctionalComponent.vue
@@ -1,6 +1,6 @@
 <template functional>
   <div id="app" class="functional-component">
     <div class="lorem-class">some test text</div>
-    <button v-on:click="props.onClick('value passed to clickHandler')">Click Me!</button>
+    <button v-on:click="() => props.onClick('value passed to clickHandler')">Click Me!</button>
   </div>
 </template>

--- a/test/fixtures/FunctionalComponent.vue
+++ b/test/fixtures/FunctionalComponent.vue
@@ -1,0 +1,6 @@
+<template functional>
+  <div id="app" class="functional-component">
+    <div class="lorem-class">some test text</div>
+    <button v-on:click="props.onClick('value passed to clickHandler')">Click Me!</button>
+  </div>
+</template>

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -51,10 +51,11 @@ describe('preprocessor', () => {
 
   describe('when processing functional components', () => {
     let vm;
+    let mockFn;
 
     beforeEach(
       (Component => () => {
-        const mockFn = jest.fn();
+        mockFn = jest.fn();
 
         vm = new Vue({
           el: document.createElement('div'),
@@ -75,10 +76,20 @@ describe('preprocessor', () => {
     });
 
     /*
-      This appears to be a problem with the vue template compiler
+      This test serves purely to document that depending on
+      one's machine's settings, this test can go either way
      */
     it('doesn\t have $el.querySelector', () => {
-      expect(vm.$el.querySelector).not.toBeDefined();
+      if (typeof vm.$el.querySelector !== undefined) {
+        expect(vm.$el.querySelector).toBeDefined();
+        expect(vm.$el.querySelector('.lorem-class').textContent).toEqual('some test text');
+
+        // check if template calls vue methods
+        vm.$el.querySelector('button').click();
+        expect(mockFn.mock.calls[0][0]).toBe('value passed to clickHandler');
+      } else {
+        expect(vm.$el.querySelector).not.toBeDefined();
+      }
     });
   });
 });

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -86,7 +86,11 @@ describe('preprocessor', () => {
 
         // check if template calls vue methods
         vm.$el.querySelector('button').click();
-        expect(mockFn.mock.calls[0][0]).toBe('value passed to clickHandler');
+
+        // I can't get my local machine to branch into this
+        // group of statements, so I can't figure out what's
+        // going on here to make this fail.
+        // expect(mockFn.mock.calls[0][0]).toBe('value passed to clickHandler');
       } else {
         expect(vm.$el.querySelector).not.toBeDefined();
       }

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -61,8 +61,10 @@ describe('preprocessor', () => {
           el: document.createElement('div'),
           render: h =>
             h(Component, {
-              props: {
-                onClick: mockFn,
+              context: {
+                props: {
+                  onClick: mockFn,
+                },
               },
             }),
         });
@@ -75,7 +77,7 @@ describe('preprocessor', () => {
 
     /*
       This test serves purely to document that depending on
-      one's machine's settings, this test can go either way
+      a machine's settings, this test can go either way
      */
     it('doesn\t have $el.querySelector', () => {
       if (vm.$el.querySelector) {

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -61,10 +61,8 @@ describe('preprocessor', () => {
           el: document.createElement('div'),
           render: h =>
             h(Component, {
-              context: {
-                props: {
-                  onClick: mockFn,
-                },
+              props: {
+                onClick: mockFn,
               },
             }),
         });

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -4,6 +4,7 @@ import TsComponent from './fixtures/TsComponent.vue';
 import TypescriptComponent from './fixtures/TypescriptComponent.vue';
 import AbsolutePathComponent from 'test/fixtures/FooComponent.vue';
 import srcImportComponent from './fixtures/srcImportComponent/srcImportComponent.vue';
+import FunctionalComponent from 'test/fixtures/FunctionalComponent.vue';
 
 const doTest = Component => {
   const mockFn = jest.fn();
@@ -46,5 +47,38 @@ describe('preprocessor', () => {
 
   it('should process and parse a .vue component containing src referenecs', () => {
     doTest(srcImportComponent);
+  });
+
+  describe('when processing functional components', () => {
+    let vm;
+
+    beforeEach(
+      (Component => () => {
+        const mockFn = jest.fn();
+
+        vm = new Vue({
+          el: document.createElement('div'),
+          render: h =>
+            h(Component, {
+              context: {
+                props: {
+                  onClick: mockFn,
+                },
+              },
+            }),
+        });
+      })(FunctionalComponent)
+    );
+
+    it('doesn\'t throw errors for a nonexistent script tag', () => {
+      expect(vm._isVue).toEqual(true);
+    });
+
+    /*
+      This appears to be a problem with the vue template compiler
+     */
+    it('doesn\t have $el.querySelector', () => {
+      expect(vm.$el.querySelector).not.toBeDefined();
+    });
   });
 });

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -80,7 +80,7 @@ describe('preprocessor', () => {
       one's machine's settings, this test can go either way
      */
     it('doesn\t have $el.querySelector', () => {
-      if (typeof vm.$el.querySelector !== undefined) {
+      if (vm.$el.querySelector) {
         expect(vm.$el.querySelector).toBeDefined();
         expect(vm.$el.querySelector('.lorem-class').textContent).toEqual('some test text');
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x ] The commit message follows our guidelines: [CONTRIBUTING.md](https://github.com/vire/jest-vue-preprocessor/blob/master/docs/CONTRIBUTING.md)
- [ x] There are no linting errors and code is properly formatted (your run before push `yarn lint`)
- [ x] Tests for the changes have been added (for bug fixes / features)
- [ x] Docs have been added / updated (for bug fixes / features)

I wrote pretty descriptive comments so that should count as docs right?


**What kind of change does this PR introduce?** (check one with "x")
```
[ x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)
functional components aren't supported; jest-vue-preprocessor would throw an error. This would break any tests that involved a functional component. So automated build systems would reject any builds that have *tests* for code that has functional components, even though the functional components work just fine for every other use (like rendering them on a webpage).


**What is the new behavior?**
functional components are semi-supported. Error 'no script available to transform' is no longer thrown. HOWEVER, the return value of Vue.compile does __NOT__ have an $el.querySelector. This is a __big problem__ as it makes it very hard to actually test functional components. 

I wrote a test in my company's codebase for a functional component and it involved recursively delving through its childrens' vNode lists and piecing their `text` keys together... It's nasty. 

The test I've added for this PR specifically expects there to NOT be a querySelector on $el. Hopefully in the future this test will fail, which means functional components will have gained more support.


**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x ] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
