### PR TITLE
fix: transform uses placeholderPattern: false

### DIFF
--- a/test/fixtures/FooComponent.vue
+++ b/test/fixtures/FooComponent.vue
@@ -1,6 +1,7 @@
 <template>
   <div id="app">
     <div class="lorem-class">some test text</div>
+    <div class="some-class">NOTAPLACEHOLDER</div>
     <button v-on:click="clickHandler('value passed to clickHandler')">Click Me!</button>
   </div>
 </template>

--- a/transforms/transformBabel.js
+++ b/transforms/transformBabel.js
@@ -18,7 +18,7 @@ function appendRenderPlugin(render, staticRenderFns) {
     );
     __vue__options__.render = ${render};
     __vue__options__.staticRenderFns = ${staticRenderFns};
-  `);
+  `, {placeholderPattern: false});
 
   return () => {
     if (!render || !staticRenderFns) {


### PR DESCRIPTION
We explicitly disable placeholderPatterns to prevent compilation errors
of valid Vue.js templates using Babel 7 transform.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: [CONTRIBUTING.md](https://github.com/vire/jest-vue-preprocessor/blob/master/docs/CONTRIBUTING.md)
- [x] There are no linting errors and code is properly formatted (your run before push `yarn lint`)
- [x] Tests for the changes have been added (for bug fixes / features)
- [] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)

You can see in the failing test case that a valid Vue.js template is not compiled successfully if it has all caps alone between two-tags. Babel transform assumes this is the start of a placeholder pattern unless it is explicitly told not to do that.

![image](https://user-images.githubusercontent.com/90510/74067912-4baae800-49c8-11ea-9ec8-7409b5d03030.png)

**What is the new behavior?**

Valid Vue.js templates are always compiled.

**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:

This issue is referenced here:

https://github.com/babel/babel/issues/8067
