### PR TITLE
fix: add missing dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,14 +23,14 @@
     "transform"
   ],
   "dependencies": {
+    "@babel/core": "7.8.7",
+    "@babel/template": "7.8.6",
     "babel-plugin-transform-runtime": "6.23.0",
     "find-babel-config": "1.2.0",
     "vue-property-decorator": "8.3.0"
   },
   "devDependencies": {
-    "@babel/core": "7.8.7",
     "@babel/preset-env": "7.8.7",
-    "@babel/template": "7.8.6",
     "babel-jest": "24.9.0",
     "commitizen": "3.1.2",
     "cz-conventional-changelog": "2.1.0",
@@ -97,7 +97,13 @@
   "peerDependencies": {
     "typescript": "*",
     "vue-template-compiler": "2.6.x",
-    "vue-template-es2015-compiler": "1.9.x"
+    "vue-template-es2015-compiler": "1.9.x",
+    "pug": "^2.0.4"
+  },
+  "peerDependenciesMeta": {
+    "pug": {
+      "optional": true
+    }
   },
   "prettier": {
     "printWidth": 100,


### PR DESCRIPTION
**What kind of change does this PR introduce?**
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?**

`jest-vue-preprocessor` is trying to use `@babel/template`, `@babel/core`, and `pug` without declaring them as dependencies

**What is the new behavior?**

- `@babel/template` and `@babel/core` have been moved from `devDependencies` to `dependencies`
- `pug` has been added as an optional peer dependency

**Does this PR introduce a breaking change?**
```
[ ] Yes
[x] No
```